### PR TITLE
Fix undefined behavior

### DIFF
--- a/include/pixelmatch.hpp
+++ b/include/pixelmatch.hpp
@@ -72,7 +72,7 @@ bool antialiased(const uint8_t* img, std::size_t x1, std::size_t y1, std::size_t
     uint64_t negatives = 0;
     double min = 0;
     double max = 0;
-    std::size_t minX, minY, maxX, maxY;
+    std::size_t minX = 0, minY = 0, maxX = 0, maxY = 0;
 
     // go through 8 adjacent pixels
     for (std::size_t x = x0; x <= x2; x++) {


### PR DESCRIPTION
```
include/pixelmatch.hpp: In function ‘bool mapbox::detail::antialiased(const uint8_t*, std::size_t, std::size_t, std::size_t, std::size_t, const uint8_t*)’:
include/pixelmatch.hpp:118:73: error: ‘maxY’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
            (!antialiased(img, maxX, maxY, width, height) && !antialiased(img2, maxX, maxY, width, height));
                                                                         ^
include/pixelmatch.hpp:118:73: error: ‘maxX’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
include/pixelmatch.hpp:117:73: error: ‘minY’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (!antialiased(img, minX, minY, width, height) && !antialiased(img2, minX, minY, width, height)) ||
                                                                         ^
include/pixelmatch.hpp:117:73: error: ‘minX’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
```
